### PR TITLE
Add conditional entropy poll selection for TLS transport

### DIFF
--- a/components/sample-azure-iot/common/transport/transport_tls_socket_using_mbedtls.c
+++ b/components/sample-azure-iot/common/transport/transport_tls_socket_using_mbedtls.c
@@ -52,12 +52,17 @@
     #elif __has_include( "mbedtls/esp_entropy.h" )
         #include "mbedtls/esp_entropy.h"
         #define MBEDTLS_ENTROPY_POLL_FN    mbedtls_hardware_poll
-    #else
-        #error "No supported entropy poll header found"
     #endif
-#else
-    #include "mbedtls/esp_entropy.h"
-    #define MBEDTLS_ENTROPY_POLL_FN    mbedtls_hardware_poll
+#endif
+
+#ifndef MBEDTLS_ENTROPY_POLL_FN
+    #if defined( ESP_PLATFORM )
+        #include "mbedtls/esp_entropy.h"
+        #define MBEDTLS_ENTROPY_POLL_FN    mbedtls_hardware_poll
+    #else
+        #include "mbedtls/entropy_poll.h"
+        #define MBEDTLS_ENTROPY_POLL_FN    mbedtls_platform_entropy_poll
+    #endif
 #endif
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
## Summary
- add conditional entropy poll header selection so the build prefers the upstream entropy poll when available and falls back to the ESP-IDF port
- use the selected entropy poll callback when registering the entropy source during TLS initialization

## Testing
- ⚠️ `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e185821ad4832988d88dc492963cbd